### PR TITLE
Add support for spark-pro-128k model

### DIFF
--- a/pkg/handler/openai_xinghuo_handler.go
+++ b/pkg/handler/openai_xinghuo_handler.go
@@ -29,6 +29,8 @@ func getURLAndDomain(modelName string) (string, string, error) {
 		return "wss://spark-api.xf-yun.com/v2.1/chat", "generalv2", nil
 	case "spark-lite", "general":
 		return "wss://spark-api.xf-yun.com/v1.1/chat", "general", nil
+	case "spark-pro-128k":
+		return "wss://spark-api.xf-yun.com/chat/pro-128k", "pro-128k", nil
 	default:
 		return "", "", fmt.Errorf("unsupported model name: %s", modelName)
 	}


### PR DESCRIPTION
增加支持星火 spark-pro-128k 模型

### 未支持前会提示如下

2024-07-31T17:50:58.668+0800    ERROR   handler/openai_handler.go:258   malformed ws or wss URL

### 支持spark-pro-128k后 已验证已通过

![Mu8LeRFA2t](https://github.com/user-attachments/assets/05811ba0-b17e-410c-a790-b53dc40654e2)

### 复现配置如下
```
{
  "server_port": ":9092",
  "load_balancing": "random",
  "debug": true,
  "log_level": "debug",
  "services": {
    "xinghuo": [
      {
        "models": ["spark-pro-128k"],
        "enabled": true,
        "credentials": {
          "appid": "**",
          "api_key": "**",
          "api_secret": "**"
        }
      }
    ]
  }
}

```


