### PR TITLE
优化对 QPM/RPM 限流的支持

### DIFF
--- a/pkg/handler/openai_handler.go
+++ b/pkg/handler/openai_handler.go
@@ -214,7 +214,7 @@ func HandleOpenAIRequest(c *gin.Context, oaiReq *openai.ChatCompletionRequest) {
 			zap.Float64("limit num:", ln),
 			zap.Int("timeout", timeout))
 
-		if lt == "qps" {
+		if lt == "qps" || lt == "qpm" {
 			err = limiter.Wait(ctx)
 			elapsed := time.Since(startWaitTime)
 

--- a/pkg/mycommon/common_credentials.go
+++ b/pkg/mycommon/common_credentials.go
@@ -35,10 +35,10 @@ func GetCredentialLimit(credentials map[string]interface{}) (limitType string, l
 		return mycomdef.KEYNAME_QPS, qps, timeout
 	}
 	if qpm, ok := limitData[mycomdef.KEYNAME_QPM].(float64); ok {
-		return mycomdef.KEYNAME_QPS, qpm / 60, timeout
+		return mycomdef.KEYNAME_QPM, qpm, timeout
 	}
 	if rpm, ok := limitData[mycomdef.KEYNAME_RPM].(float64); ok {
-		return mycomdef.KEYNAME_QPS, rpm / 60, timeout
+		return mycomdef.KEYNAME_QPM, rpm, timeout
 	}
 	if concurrency, ok := limitData[mycomdef.KEYNAME_CONCURRENCY].(float64); ok {
 		return mycomdef.KEYNAME_CONCURRENCY, concurrency, timeout

--- a/pkg/mycommon/common_modeldetails.go
+++ b/pkg/mycommon/common_modeldetails.go
@@ -10,9 +10,9 @@ func GetServiceModelDetailsLimit(s *config.ModelDetails) (limitType string, limi
 	if s.Limit.QPS > 0 {
 		return mycomdef.KEYNAME_QPS, s.Limit.QPS, s.Limit.Timeout
 	} else if s.Limit.QPM > 0 {
-		return mycomdef.KEYNAME_QPS, s.Limit.QPM / 60, s.Limit.Timeout
+		return mycomdef.KEYNAME_QPM, s.Limit.QPM, s.Limit.Timeout
 	} else if s.Limit.RPM > 0 {
-		return mycomdef.KEYNAME_QPS, s.Limit.QPM / 60, s.Limit.Timeout
+		return mycomdef.KEYNAME_QPM, s.Limit.RPM, s.Limit.Timeout
 	} else if s.Limit.Concurrency > 0 {
 		return mycomdef.KEYNAME_CONCURRENCY, s.Limit.Concurrency, s.Limit.Timeout
 	}


### PR DESCRIPTION
# 基于滑动窗口算法实现真正的 QPM/RPM 支持

## 主要变更
- 新增 `SlidingWindowLimiter` 实现 QPM/RPM 限流
- 更新 `Limiter` 结构体和相关方法以支持新的限流器
- 修改 `GetServiceModelDetailsLimit` 函数，直接返回 QPM 而非转换为 QPS

## 变更原因

在原先的实现中，QPM 和 RPM 的 limit 会被简单处理为 value / 60 的 QPS。

例如，groq 的单个模型请求限制是 30 QPM，会被转化为 0.5 QPS，进而导致模型不可用。

新实现使用滑动窗口算法，更精确地限制任意 60 秒内的请求数，更贴近后端服务的实际行为。

## 注意事项
- 请重点测试依赖 QPM/RPM 限制的服务
- 审查 `SlidingWindowLimiter` 的实现和 `GetServiceModelDetailsLimit` 的变更
- 考虑新实现在内存使用和精确度之间的权衡