### PR TITLE
feat(adapter): 添加 CozeCN V3 流式响应的思考内容支持 && 修复响应为空时的报错

### DIFF
--- a/pkg/adapter/cozecn_v3_openai.go
+++ b/pkg/adapter/cozecn_v3_openai.go
@@ -136,12 +136,27 @@ func CozecnV3ReponseToOpenAIResponse(resp *chat_message_list.MessageListResponse
 func CozecnV3ReponseToOpenAIResponseStream(resp *streammode.EventData) *myopenai.OpenAIStreamResponse {
 	var choices []myopenai.OpenAIStreamResponseChoice
 
+	role := resp.Role
+	if resp.Content == "" {
+		role = "assistant"
+	}
+
+	// 构建 delta：content 保持不变，reasoning_content 独立字段
+	delta := myopenai.ResponseDelta{
+		Role:    role,
+		Content: resp.Content,
+	}
+
+	// 如果存在思考内容，添加到 ReasoningContent 字段
+	if resp.ReasoningContent != "" {
+		delta.ReasoningContent = resp.ReasoningContent
+	} else if resp.Thinking != "" {
+		delta.ReasoningContent = resp.Thinking
+	}
+
 	choices = append(choices, myopenai.OpenAIStreamResponseChoice{
 		Index: 0,
-		Delta: myopenai.ResponseDelta{
-			Role:    resp.Role,
-			Content: resp.Content,
-		},
+		Delta: delta,
 	})
 	usage := myopenai.Usage{
 		PromptTokens:     resp.Usage.InputCount,
@@ -153,8 +168,7 @@ func CozecnV3ReponseToOpenAIResponseStream(resp *streammode.EventData) *myopenai
 		Object:  "chat.completion.chunk",
 		Created: time.Now().Unix(),
 		Choices: choices,
-		//Error:   errorDetail,
-		Usage: &usage,
+		Usage:   &usage,
 	}
 	return nil
 }

--- a/pkg/llm/devplatform/cozecn_v3/streammode/response.go
+++ b/pkg/llm/devplatform/cozecn_v3/streammode/response.go
@@ -20,4 +20,6 @@ type EventData struct {
 		OutputCount int `json:"output_count"`
 		InputCount  int `json:"input_count"`
 	} `json:"usage"`
+	ReasoningContent string `json:"reasoning_content,omitempty"` // 工作流模式的思考过程（Coze字段）
+	Thinking         string `json:"thinking,omitempty"`          // 兼容字段（某些版本可能使用）
 }

--- a/pkg/openai/openai_response.go
+++ b/pkg/openai/openai_response.go
@@ -49,9 +49,10 @@ type ResponseMessage struct {
 
 // ResponseDelta Delta 定义了对话中的消息结构
 type ResponseDelta struct {
-	Role      string     `json:"role"`
-	Content   string     `json:"content"`
-	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+	Role             string     `json:"role"`
+	Content          string     `json:"content,omitempty"`
+	ReasoningContent string     `json:"reasoning_content,omitempty"` // 思考内容（兼容Coze工作流）
+	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`
 }
 
 // Usage 定义了使用统计的结构


### PR DESCRIPTION
- 在 ResponseDelta 结构中新增 ReasoningContent 字段用于存储思考内容
- 实现了对 Coze 工作流模式思考过程的支持和兼容处理
- 修复了角色判断逻辑，当响应内容为空时默认设置为 assistant 角色
- 统一了思考内容的字段映射，兼容 reasoning_content 和 thinking 字段
- 重构了 delta 构建逻辑以支持独立的 ReasoningContent 字段处理
- 图片：查看修复前后对比
<img width="983" height="1220" alt="one-simple-api-fix-cozecn" src="https://github.com/user-attachments/assets/986eecd1-0bb7-4e0c-a82e-ca85f0129af4" />
