### PR TITLE
fix(embedding): respect server_url for openai embedding provider

### DIFF
--- a/pkg/embedding/embeddings_handler.go
+++ b/pkg/embedding/embeddings_handler.go
@@ -75,7 +75,7 @@ func EmbeddingsHandler(c *gin.Context) {
 	case "qianfan":
 		oaiResp, err = baiduqianfan.BaiduQianfanEmbedding(&oaiEmbReq, apiKey, secretKey, proxyTransport)
 	case "openai":
-		oaiResp, err = oai.OpenAIEmbedding(&oaiEmbReq, apiKey, proxyTransport)
+		oaiResp, err = oai.OpenAIEmbedding(&oaiEmbReq, apiKey, s.ServerURL, proxyTransport)
 	default:
 		mylog.Logger.Error("Unsupported service", zap.String("service", s.ServiceName))
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Unsupported service"})

--- a/pkg/embedding/oai/oai_embedding.go
+++ b/pkg/embedding/oai/oai_embedding.go
@@ -6,13 +6,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
 // GenerateEmbedding 生成文本的嵌入向量
-func OpenAIEmbedding(embReq *EmbeddingRequest, apiKey string, proxyTransport *http.Transport) (*EmbeddingResponse, error) {
+func OpenAIEmbedding(embReq *EmbeddingRequest, apiKey string, serverURL string, proxyTransport *http.Transport) (*EmbeddingResponse, error) {
 
-	url := "https://api.openai.com/v1/embeddings"
+	url := serverURL
+	if url == "" {
+		url = "https://api.openai.com/v1/embeddings"
+	} else {
+		url = strings.TrimRight(url, "/") + "/embeddings"
+	}
 	requestBody, err := json.Marshal(embReq)
 	if err != nil {
 		return nil, fmt.Errorf("JSON 编码错误: %v", err)


### PR DESCRIPTION
openai 类型 embedding 的请求 URL 目前写死为 https://api.openai.com/v1/embeddings，没有使用 Provider 配置的 server_url，导致 embedding 无法转发到自建的 OpenAI 兼容服务（如本地 TEI、Ollama）。chat 路径已支持 server_url，embedding 这里不一致。

修改：将 s.ServerURL 传入 OpenAIEmbedding，按 serverURL + "/embeddings" 拼请求地址；server_url 为空时回退官方地址，向后兼容，不影响存量配置。